### PR TITLE
Small fixes to audio-cpp's CI

### DIFF
--- a/.github/workflows/clang-format-deploy.yml
+++ b/.github/workflows/clang-format-deploy.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     
     - name: 🌐 Downloading .clang-format from audio-wrappers
-      run: wget https://raw.githubusercontent.com/engine3d-dev/audio-cpp/.clang-format -O .clang-format
+      run: wget https://github.com/engine3d-dev/audio-cpp/blob/main/.clang-format -O .clang-format
     
     - uses: actions/checkout@v4
     - name: Run clang-format style check for C/C++/Protobuf programs.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,8 +27,5 @@ jobs:
             - name: Installing project dependencies
               run: conan remote add engine3d-conan https://libhal.jfrog.io/artifactory/api/conan/engine3d-conan
 
-            - name: Cloning audio-cpp repository
-              run: git clone https://github.com/engine3d-dev/audio-cpp
-
-            - name: Building audio-wrappers
+            - name: Building audio-cpp
               run: conan build . -b missing -c tools.system.package_manager:sudo=True -c tools.system.package_manager:mode=install

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -31,8 +31,5 @@ jobs:
             - name: Installing Atlas repositories
               run: conan remote add engine3d-conan https://libhal.jfrog.io/artifactory/api/conan/engine3d-conan
 
-            - name: Cloning audio-cpp repository
-              run: git clone https://github.com/engine3d-dev/audio-cpp
-
-            - name: Building the project
+            - name: Building audio-cpp
               run: conan build . -b missing

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,6 @@ jobs:
             shell: pwsh
             run: conan remote add engine3d-conan https://libhal.jfrog.io/artifactory/api/conan/engine3d-conan
           
-          - name: Running Test Cases
+          - name: Building audio-cpp
             shell: pwsh
             run: conan build . -b missing


### PR DESCRIPTION
Removed the commands for cloning the repo as that is automated to be expected to directly compile audio-cpp implicitly. Fixing some bugs that kept failing the CI.